### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blog-post-workflow.yml
+++ b/.github/workflows/blog-post-workflow.yml
@@ -3,9 +3,13 @@ on:
   schedule: # Run workflow automatically
     - cron: '0 * * * *' # Runs every hour, on the hour
   workflow_dispatch: # Run workflow manually (without waiting for the cron to be called), through the Github Actions Workflow page directly
+permissions:
+  contents: read
 jobs:
   update-readme-with-blog:
     name: Update this repo's README with latest blog posts
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Potential fix for [https://github.com/jai-dewani/blogs/security/code-scanning/2](https://github.com/jai-dewani/blogs/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/blog-post-workflow.yml` so the workflow does not rely on inherited defaults.  
Best fix without changing functionality: set default workflow permissions to `contents: read`, then grant only this job elevated permission `contents: write` because it updates README content/commits changes. This follows least privilege while preserving expected behavior.

Edit regions:
- At workflow root (after `on:` block): add `permissions: contents: read`.
- Inside `jobs.update-readme-with-blog`: add a job-level `permissions: contents: write`.

No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
