### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jai-dewani/blogs/security/code-scanning/1](https://github.com/jai-dewani/blogs/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/deploy.yml` so the workflow no longer relies on repository/org defaults.

Best single fix without changing intended behavior:
- Set workflow-level permissions with least privilege needed for this deploy pipeline.
- Since this workflow publishes to `gh-pages`, it needs to write repository contents; checkout needs read.
- Add:
  - `contents: write`

Specific change region:
- File: `.github/workflows/deploy.yml`
- Insert `permissions:` block after the `on:` trigger section and before `jobs:`.

No imports, methods, or additional definitions are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
